### PR TITLE
Add support for YAML-CPP 0.5+.

### DIFF
--- a/bwi_planning/CMakeLists.txt
+++ b/bwi_planning/CMakeLists.txt
@@ -9,6 +9,12 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
 )
 find_package(Boost REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
+
+if(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
 
 catkin_python_setup()
 
@@ -37,10 +43,10 @@ catkin_package(
 )
 
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/libbwi_planning/cost_learner.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${YAML_CPP_LIBRARIES})
 
 add_executable(cost_learner src/nodes/cost_learner.cpp)
 target_link_libraries(cost_learner ${PROJECT_NAME})

--- a/bwi_planning/package.xml
+++ b/bwi_planning/package.xml
@@ -24,6 +24,7 @@
   <build_depend>roslaunch</build_depend> <!-- unit test only -->
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>yaml-cpp</build_depend>
 
   <run_depend>bwi_planning_common</run_depend>
   <run_depend>clasp</run_depend>
@@ -33,6 +34,7 @@
   <run_depend>sound_play</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
+  <run_depend>yaml-cpp</run_depend>
 
   <!-- launch only dependencies -->
   <run_depend>segbot_gazebo</run_depend>

--- a/bwi_planning/src/libbwi_planning/cost_learner.cpp
+++ b/bwi_planning/src/libbwi_planning/cost_learner.cpp
@@ -5,8 +5,21 @@
 #include <fstream>
 #include <ros/ros.h>
 #include <stdexcept>
+#include <yaml-cpp/yaml.h>
 
 #include <bwi_planning/cost_learner.h>
+
+#ifdef HAVE_NEW_YAMLCPP
+namespace YAML {
+  // The >> operator disappeared in yaml-cpp 0.5, so this function is
+  // added to provide support for code written under the yaml-cpp 0.3 API.
+  template<typename T>
+  void operator >> (const YAML::Node& node, T& i)
+  {
+    i = node.as<T>();
+  }
+}
+#endif
 
 namespace bwi_planning {
 
@@ -162,10 +175,14 @@ namespace bwi_planning {
     std::string in_file_name = values_file_ + 
       boost::lexical_cast<std::string>(episode);
     std::ifstream fin(in_file_name.c_str());
-    YAML::Parser parser(fin);
 
     YAML::Node doc;
+#ifdef HAVE_NEW_YAMLCPP
+    doc = YAML::Load(fin);
+#else
+    YAML::Parser parser(fin);
     parser.GetNextDocument(doc);
+#endif
 
     for (size_t i = 0; i < doc.size(); ++i) {
       std::string loc;


### PR DESCRIPTION
The new yaml-cpp API removes the "node >> outputvar;" operator, and it has a new way of loading documents. There's no version hint in the library's headers, so I'm getting the version number from pkg-config.

`bwi_planning` also directly references yaml-cpp code in `src/libbwi_planning/cost_learner.cpp` but does not depend on it like it should, so that was added. I think it didn't cause a build failure because an upstream library had already linked against it.
